### PR TITLE
fix: only java 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ catalog.db
 
 # build
 dist/
+
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple UI for browsing an Iceberg catalog. It's still under developmen
 
 ## Development
 
-To develop, JRE >= 17 and Node.js >= 23 are required.
+To develop, JDK 17 and Node.js >= 23 are required.
 
 Start the server with:
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,14 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
 repositories {
   mavenCentral()
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "NODE_OPTIONS=\"--loader ts-node/esm\" webpack serve --mode development",
-    "build": "NODE_OPTIONS=\"--loader ts-node/esm\" webpack --mode production",
+    "dev": "webpack serve --mode development",
+    "build": "webpack --mode production",
     "lint": "eslint src/**/*.{ts,tsx}"
   },
   "dependencies": {


### PR DESCRIPTION
Because Spark runs on Java 8/11/17.

Java 23 errors with: (Perhaps other versions like 21 may work, but just be safe)
```
2025-03-28T14:05:51.436 INFO  [org.apache.spark.SparkContext] - Java version 23.0.2
2025-03-28T14:05:51.531 WARN  [org.apache.hadoop.util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Exception in thread "main" java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
        at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
        at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:577)
        at org.apache.spark.util.Utils$.$anonfun$getCurrentUserName$1(Utils.scala:2416)
        at scala.Option.getOrElse(Option.scala:189)
        at org.apache.spark.util.Utils$.getCurrentUserName(Utils.scala:2416)
        at org.apache.spark.SparkContext.<init>(SparkContext.scala:334)
        at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2888)
        at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:1099)
        at scala.Option.getOrElse(Option.scala:189)
        at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:1093)
        at io.nimtable.spark.LocalSpark.initializeSpark(LocalSpark.java:44)
        at io.nimtable.spark.LocalSpark.<init>(LocalSpark.java:12)
        at io.nimtable.spark.LocalSpark.getInstance(LocalSpark.java:17)
        at io.nimtable.SparkQueryServlet.<init>(SparkQueryServlet.java:28)
        at io.nimtable.Server.main(Server.java:
```

Signed-off-by: xxchan <xxchan22f@gmail.com>