### PR TITLE
feat: improve sql-editor style

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,20 @@ cd backend
 ./gradlew run
 ```
 
+It will serve at http://localhost:8182.
+
 ### Frontend Development
 
-```bash
+First start the backend server as mentioned above.
+
 # Install dependencies
 npm install
 
 # Start development server
 npm run dev
 ```
+
+It will serve a separate UI at http://localhost:3000, which can be dynamically updated as you make changes to the frontend code.
 
 ### Testing with a Catalog
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'export',
+    // rewrites is only for development (npm run dev); it won't affect static export
+    rewrites: () => [
+        {
+            source: "/api/:path*",
+            destination: "http://localhost:8182/api/:path*",
+        },
+    ],
 };
 
 module.exports = nextConfig

--- a/src/lib/sql-highlighter.ts
+++ b/src/lib/sql-highlighter.ts
@@ -15,7 +15,8 @@
  */
 import Prism from 'prismjs'
 import 'prismjs/components/prism-sql'
-import 'prismjs/themes/prism-tomorrow.css'
+import "@/styles/sql-editor.css"
+
 
 /**
  * Highlights SQL code using Prism.js

--- a/src/styles/sql-editor.css
+++ b/src/styles/sql-editor.css
@@ -1,0 +1,128 @@
+/* Modified from 
+https://github.com/PrismJS/prism/blob/76dde18a575831c91491895193f56081ac08b0c5/themes/prism-tomorrow.css 
+With the color palette from https://github.com/chriskempson/tomorrow-theme/blob/ccf6666d888198d341b26b3a99d0bc96500ad503/vim/colors/Tomorrow.vim
+*/
+
+/**
+ * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
+ * Based on https://github.com/chriskempson/tomorrow-theme
+ * @author Rose Pritchard
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+    color: #4d4d4c;
+    background: none;
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    font-size: 1em;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
+
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+    padding: 1em;
+    margin: .5em 0;
+    overflow: auto;
+}
+
+:not(pre)>code[class*="language-"],
+pre[class*="language-"] {
+    background: #2d2d2d;
+}
+
+/* Inline code */
+:not(pre)>code[class*="language-"] {
+    padding: .1em;
+    border-radius: .3em;
+    white-space: normal;
+}
+
+.token.comment,
+.token.block-comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #8e908c;
+}
+
+.token.punctuation {
+    color: #8e908c;
+}
+
+.token.tag,
+.token.attr-name,
+.token.namespace,
+.token.deleted {
+    color: #c82829;
+}
+
+.token.function-name {
+    color: #4271ae;
+}
+
+.token.boolean,
+.token.number,
+.token.function {
+    color: #f5871f;
+}
+
+.token.property,
+.token.class-name,
+.token.constant,
+.token.symbol {
+    color: #f5871f;
+}
+
+.token.selector,
+.token.important,
+.token.atrule,
+.token.keyword,
+.token.builtin {
+    color: #8959a8;
+}
+
+.token.string,
+.token.char,
+.token.attr-value,
+.token.regex,
+.token.variable {
+    color: #718c00;
+}
+
+.token.operator,
+.token.entity,
+.token.url {
+    color: #3e999f;
+}
+
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
+}
+
+.token.entity {
+    cursor: help;
+}
+
+.token.inserted {
+    color: #718c00;
+}


### PR DESCRIPTION
The theme prism-tomorrow.css is a dark theme, and looks very dim.

Also fix `npm run dev`

Compare:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/6e383012-663f-470b-98c1-f2d61a5c6506" />

<img width="808" alt="image" src="https://github.com/user-attachments/assets/e730831d-54d2-48e1-9aeb-b8bf03f873f6" />
