### PR TITLE
fix: docker java opts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,19 +52,19 @@ COPY --from=build /nimtable/backend/build/libs/nimtable-all.jar /nimtable/nimtab
 EXPOSE 8182
 
 # Run the application
-ENTRYPOINT ["java", \
-    "--add-opens=java.base/java.lang=ALL-UNNAMED", \
-    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED", \
-    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", \
-    "--add-opens=java.base/java.io=ALL-UNNAMED", \
-    "--add-opens=java.base/java.net=ALL-UNNAMED", \
-    "--add-opens=java.base/java.nio=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.security.action=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED", \
-    "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED", \
-    "-jar", "/nimtable/nimtable.jar"] 
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.io=ALL-UNNAMED \
+    --add-opens=java.base/java.net=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/java.util=ALL-UNNAMED \
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
+    --add-opens=java.base/sun.security.action=ALL-UNNAMED \
+    --add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
+    --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED \
+    -jar /nimtable/nimtable.jar"] 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -10,22 +10,22 @@ COPY ./nimtable-all.jar /nimtable/nimtable.jar
 EXPOSE 8182
 
 # Run the application
-ENTRYPOINT ["java", \
-    "--add-opens=java.base/java.lang=ALL-UNNAMED", \
-    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED", \
-    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", \
-    "--add-opens=java.base/java.io=ALL-UNNAMED", \
-    "--add-opens=java.base/java.net=ALL-UNNAMED", \
-    "--add-opens=java.base/java.nio=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", \
-    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.security.action=ALL-UNNAMED", \
-    "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED", \
-    "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED", \
-    "-jar", "/nimtable/nimtable.jar"] 
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.io=ALL-UNNAMED \
+    --add-opens=java.base/java.net=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/java.util=ALL-UNNAMED \
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
+    --add-opens=java.base/sun.security.action=ALL-UNNAMED \
+    --add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
+    --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED \
+    -jar /nimtable/nimtable.jar"] 
 
 FROM node:23-alpine AS nimtable-frontend-runtime
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - source: config.yaml
         target: /nimtable/config.yaml
     environment:
-      JAVA_OPTS: -Xmx2g -Xms512m
+      JAVA_OPTS: -Xmx32g -Xms512m
     networks:
       - nimtable-network
 


### PR DESCRIPTION
This pull request updates the Docker configuration for the `nimtable` project, introducing changes to improve flexibility and resource allocation. The most significant updates include modifying the `ENTRYPOINT` commands in Dockerfiles to support dynamic Java options and increasing the default maximum heap size for the Java application in the `docker-compose.yml` file.