### PR TITLE
feat: refine manifest display

### DIFF
--- a/backend/src/main/java/io/nimtable/ManifestServlet.java
+++ b/backend/src/main/java/io/nimtable/ManifestServlet.java
@@ -149,6 +149,9 @@ public class ManifestServlet extends HttpServlet {
                 rootNode.put("content", manifest.content().name());
                 var filesNode = objectMapper.createArrayNode();
 
+                // Note: ManifestFiles.read() and ManifestFiles.readDeleteManifest() only return
+                // non-deleted entries. Deleted entries in the manifest will not be included in the
+                // response.
                 switch (manifest.content()) {
                     case DATA:
                         for (DataFile file : ManifestFiles.read(manifest, fileIO, table.specs())) {

--- a/src/app/table/snapshots.tsx
+++ b/src/app/table/snapshots.tsx
@@ -429,7 +429,9 @@ function ManifestItem({
                       <div className="text-sm font-medium">Files</div>
                       {manifest.deleted_files_count > 0 && (
                         <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded border">
-                          ⚠️ Note: Only non-deleted entries are displayed. {manifest.deleted_files_count} deleted entries in the manifest are not shown.
+                          ⚠️ Note: Only non-deleted entries are displayed.{" "}
+                          {manifest.deleted_files_count} deleted entries in the
+                          manifest are not shown.
                         </div>
                       )}
                       {manifestDetails.files.length > 0 ? (
@@ -488,7 +490,9 @@ function ManifestItem({
               <div className="text-sm font-medium">Files</div>
               {manifest.deleted_files_count > 0 && (
                 <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded border">
-                  ⚠️ Note: Only non-deleted entries are displayed. {manifest.deleted_files_count} deleted entries in the manifest are not shown.
+                  ⚠️ Note: Only non-deleted entries are displayed.{" "}
+                  {manifest.deleted_files_count} deleted entries in the manifest
+                  are not shown.
                 </div>
               )}
               {manifestDetails.files.length > 0 ? (

--- a/src/app/table/snapshots.tsx
+++ b/src/app/table/snapshots.tsx
@@ -427,6 +427,11 @@ function ManifestItem({
                   {manifestDetails && (
                     <div className="space-y-2">
                       <div className="text-sm font-medium">Files</div>
+                      {manifest.deleted_files_count > 0 && (
+                        <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded border">
+                          ⚠️ Note: Only non-deleted entries are displayed. {manifest.deleted_files_count} deleted entries in the manifest are not shown.
+                        </div>
+                      )}
                       {manifestDetails.files.length > 0 ? (
                         <div className="max-h-[300px] space-y-3 overflow-y-auto">
                           {manifestDetails.files.map((file, fileIndex) => (
@@ -481,12 +486,17 @@ function ManifestItem({
           ) : manifestDetails ? (
             <div className="space-y-4">
               <div className="text-sm font-medium">Files</div>
+              {manifest.deleted_files_count > 0 && (
+                <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-1 rounded border">
+                  ⚠️ Note: Only non-deleted entries are displayed. {manifest.deleted_files_count} deleted entries in the manifest are not shown.
+                </div>
+              )}
               {manifestDetails.files.length > 0 ? (
-                <div className="space-y-3">
+                <div className="max-h-[300px] space-y-3 overflow-y-auto">
                   {manifestDetails.files.map((file, fileIndex) => (
                     <div
                       key={fileIndex}
-                      className="space-y-1 pl-2 font-mono text-xs"
+                      className="space-y-1 border-l-2 border-muted pl-2 font-mono text-xs"
                     >
                       <div className="text-muted-foreground">
                         Path: {file.file_path}


### PR DESCRIPTION
- Since our java api of manifest file reader can only read non-deleted files, we need to notify users that not all manifest entries are shown.