### PR TITLE
bugfix: support nested namespaces in catalog browsing

### DIFF
--- a/backend/src/main/java/io/nimtable/DistributionServlet.java
+++ b/backend/src/main/java/io/nimtable/DistributionServlet.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.nimtable.cache.DataDistributionCache;
 import io.nimtable.db.entity.DataDistribution;
 import io.nimtable.db.repository.CatalogRepository;
+import io.nimtable.util.NamespaceUtil;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -163,7 +164,7 @@ public class DistributionServlet extends HttpServlet {
             }
         }
 
-        Table table = catalog.loadTable(TableIdentifier.of(namespace, tableName));
+        Table table = catalog.loadTable(TableIdentifier.of(NamespaceUtil.parse(namespace), tableName));
 
         Snapshot snapshot;
         if (snapshotId != null) {

--- a/backend/src/main/java/io/nimtable/ManifestServlet.java
+++ b/backend/src/main/java/io/nimtable/ManifestServlet.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.nimtable.db.entity.Catalog;
 import io.nimtable.db.repository.CatalogRepository;
+import io.nimtable.util.NamespaceUtil;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -99,7 +100,7 @@ public class ManifestServlet extends HttpServlet {
         try {
             table =
                     CatalogUtil.buildIcebergCatalog(catalogName, properties, new Configuration())
-                            .loadTable(TableIdentifier.of(namespace, tableName));
+                            .loadTable(TableIdentifier.of(NamespaceUtil.parse(namespace), tableName));
         } catch (Exception e) {
             logger.error("Failed to load table: {}.{}", namespace, tableName, e);
             response.sendError(

--- a/backend/src/main/java/io/nimtable/OptimizeServlet.java
+++ b/backend/src/main/java/io/nimtable/OptimizeServlet.java
@@ -23,6 +23,7 @@ import io.nimtable.db.repository.CatalogRepository;
 import io.nimtable.db.repository.ScheduledTaskRepository;
 import io.nimtable.spark.LocalSpark;
 import io.nimtable.util.CronUtil;
+import io.nimtable.util.NamespaceUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -224,7 +225,7 @@ public class OptimizeServlet extends HttpServlet {
         try {
             table =
                     CatalogUtil.buildIcebergCatalog(catalogName, properties, new Configuration())
-                            .loadTable(TableIdentifier.of(namespace, tableName));
+                            .loadTable(TableIdentifier.of(NamespaceUtil.parse(namespace), tableName));
         } catch (Exception e) {
             logger.error("Failed to load table: {}.{}", namespace, tableName, e);
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);

--- a/backend/src/main/java/io/nimtable/util/NamespaceUtil.java
+++ b/backend/src/main/java/io/nimtable/util/NamespaceUtil.java
@@ -20,11 +20,12 @@ import org.apache.iceberg.catalog.Namespace;
 
 public final class NamespaceUtil {
 
-    // Multi-level namespace parts arrive from the frontend separated by the 0x1F
-    // unit separator on the wire (see the web data-loader `namespaceParts`). Split
-    // on it to rebuild a real multi-level Namespace; a flat namespace yields a
-    // single element.
-    private static final String SEPARATOR = "\\u001f";
+    // Nimtable's per-table endpoints (distribution/manifest/optimize) receive the
+    // namespace as one path segment with levels joined by '.', matching the
+    // frontend's internal dot-separated representation (see web data-loader; the
+    // 0x1F separator is used only on the Iceberg REST listing path). Split on '.'
+    // to rebuild a real multi-level Namespace; a flat namespace yields one element.
+    private static final String SEPARATOR = "\\.";
 
     private NamespaceUtil() {}
 

--- a/backend/src/main/java/io/nimtable/util/NamespaceUtil.java
+++ b/backend/src/main/java/io/nimtable/util/NamespaceUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.util;
+
+import org.apache.iceberg.catalog.Namespace;
+
+public final class NamespaceUtil {
+
+    // Multi-level namespace parts arrive from the frontend separated by the 0x1F
+    // unit separator on the wire (see the web data-loader `namespaceParts`). Split
+    // on it to rebuild a real multi-level Namespace; a flat namespace yields a
+    // single element.
+    private static final String SEPARATOR = "\\u001f";
+
+    private NamespaceUtil() {}
+
+    public static Namespace parse(String namespace) {
+        return Namespace.of(namespace.split(SEPARATOR));
+    }
+}

--- a/backend/src/main/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/backend/src/main/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -321,10 +321,9 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
 
             case LIST_NAMESPACES:
                 if (asNamespaceCatalog != null) {
-                    // NOTE: Treat missing/blank `parent` as "list root namespaces".
-                    // Some Iceberg catalog implementations throw when asked to list namespaces
-                    // under
-                    // Namespace.empty(), so we must avoid passing it as a "parent namespace".
+                    // NOTE: Treat missing/blank `parent` as "list root namespaces". Splitting a
+                    // blank string would yield a single-level namespace named "" rather than
+                    // Namespace.empty(), which CatalogHandlers routes to the root listing.
                     final String parent = vars.get("parent");
                     final boolean hasParent = parent != null && !parent.trim().isEmpty();
                     Namespace ns =
@@ -333,37 +332,20 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
                                             RESTUtil.NAMESPACE_SPLITTER
                                                     .splitToStream(parent)
                                                     .toArray(String[]::new))
-                                    : null;
+                                    : Namespace.empty();
 
                     String pageToken = PropertyUtil.propertyAsString(vars, "pageToken", null);
                     String pageSize = PropertyUtil.propertyAsString(vars, "pageSize", null);
 
                     if (pageSize != null) {
-                        if (ns == null) {
-                            // Graceful fallback: treat this server as "no pagination support" for
-                            // root listing.
-                            return castResponse(
-                                    responseType,
-                                    ListNamespacesResponse.builder()
-                                            .addAll(asNamespaceCatalog.listNamespaces())
-                                            .build());
-                        }
                         return castResponse(
                                 responseType,
                                 CatalogHandlers.listNamespaces(
                                         asNamespaceCatalog, ns, pageToken, pageSize));
                     } else {
-                        if (ns != null && ns.length() > 0) {
-                            // only support one level of namespace listing
-                            return castResponse(
-                                    responseType, ListNamespacesResponse.builder().build());
-                        } else {
-                            return castResponse(
-                                    responseType,
-                                    ListNamespacesResponse.builder()
-                                            .addAll(asNamespaceCatalog.listNamespaces())
-                                            .build());
-                        }
+                        return castResponse(
+                                responseType,
+                                CatalogHandlers.listNamespaces(asNamespaceCatalog, ns));
                     }
                 }
                 break;

--- a/src/app/data/hooks/useNamespaces.tsx
+++ b/src/app/data/hooks/useNamespaces.tsx
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query"
 
 import { loadNamespacesAndTables } from "@/lib/data-loader"
+import type { NamespaceTables } from "@/lib/data-loader"
 
 export interface Namespace {
   id: string
@@ -21,18 +22,22 @@ export function useNamespaces(catalogs: string[]) {
       })) || [],
   })
 
-  // Combine all namespaces data
+  // Combine all namespaces data, flattening nested namespaces
   const allNamespaces = namespaceQueries
     .flatMap((query, index) => {
       if (!query.data) return []
       const catalog = catalogs?.[index] || ""
-      return query.data.map((ns) => ({
-        id: ns.name,
-        name: ns.shortName,
-        catalog: catalog,
-        tableCount: ns.tables.length,
-        tables: ns.tables,
-      }))
+      const flatten = (ns: NamespaceTables): Namespace[] => [
+        {
+          id: ns.name,
+          name: ns.name,
+          catalog: catalog,
+          tableCount: ns.tables.length,
+          tables: ns.tables,
+        },
+        ...ns.children.flatMap(flatten),
+      ]
+      return query.data.flatMap(flatten)
     })
     .filter(Boolean)
 

--- a/src/lib/data-loader.ts
+++ b/src/lib/data-loader.ts
@@ -40,6 +40,55 @@ function isBrowser() {
   return typeof window !== "undefined"
 }
 
+// Multipart namespace parts are separated by 0x1F on the wire ("%1F"
+// url-encoded). Servers may advertise a different separator via the
+// `namespace-separator` config override; Nimtable's backend uses the
+// default, and spec-compliant servers must always accept 0x1F. Names
+// internal to Nimtable remain `.`-separated.
+const NAMESPACE_SEPARATOR = "\u001f"
+const NAMESPACE_SEPARATOR_ENCODED = "%1F"
+
+function namespaceParts(namespace: string): string[] {
+  return namespace
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+function cleanNamespaces(namespaces: string[][] | undefined): string[][] {
+  return (namespaces || [])
+    .map((ns) => (ns || []).map((p) => (p ?? "").trim()).filter(Boolean))
+    .filter((ns) => ns.length > 0)
+}
+
+function encodeNamespace(parts: string[]): string {
+  return parts.map(encodeURIComponent).join(NAMESPACE_SEPARATOR_ENCODED)
+}
+
+function namespaceToQueryParam(parts: string[]): string {
+  return parts.join(NAMESPACE_SEPARATOR)
+}
+
+async function listChildNamespaces(
+  api: ReturnType<typeof catalogApi>,
+  parentParts: string[]
+): Promise<string[][]> {
+  const namespaces: string[][] = []
+  let pageToken: string | null = ""
+  do {
+    const response = await api.v1.listNamespaces({
+      ...(parentParts.length
+        ? { parent: namespaceToQueryParam(parentParts) }
+        : {}),
+      pageSize: 100,
+      pageToken,
+    })
+    namespaces.push(...(response.namespaces || []))
+    pageToken = response["next-page-token"] ?? null
+  } while (pageToken !== null)
+  return namespaces
+}
+
 export async function loadCatalogNames(): Promise<string[]> {
   try {
     // Create a properly configured client for server-side or browser-side usage
@@ -85,70 +134,33 @@ export async function loadNamespacesAndTables(
 ): Promise<NamespaceTables[]> {
   const api = catalogApi(catalog, inBrowser)
 
-  function normalizeNamespaceParts(parts: string[]): string[] | null {
-    const cleaned = (parts || []).map((p) => (p ?? "").trim()).filter(Boolean)
-    return cleaned.length > 0 ? cleaned : null
-  }
-
   async function fetchNamespaceAndChildren(
-    namespace: string[]
+    parts: string[]
   ): Promise<NamespaceTables> {
-    const normalized = normalizeNamespaceParts(namespace)
-    const namespaceName = normalized ? normalized.join(".") : ""
-
-    // Root (empty) namespace isn't a real namespace; don't query tables for it.
-    const tablesResponse = namespaceName
-      ? await api.v1.listTables(namespaceName)
-      : { identifiers: [] as any[] }
-
-    // Get child namespaces
-    // Important: do NOT send `parent` when it is empty, otherwise Iceberg REST
-    // servers may interpret it as an empty namespace and return 404.
-    const childNamespacesResponse = namespaceName
-      ? await api.v1.listNamespaces({ parent: namespaceName })
-      : await api.v1.listNamespaces()
-    const childNamespaces = childNamespacesResponse.namespaces || []
+    const [tablesResponse, childNamespaces] = await Promise.all([
+      api.v1.listTables(encodeNamespace(parts)),
+      listChildNamespaces(api, parts),
+    ])
 
     // Recursively fetch child namespaces
     const children = await Promise.all(
-      childNamespaces
-        .map((child) => normalizeNamespaceParts(child))
-        .filter((child): child is string[] => !!child)
-        .map((child) => fetchNamespaceAndChildren(child))
+      cleanNamespaces(childNamespaces).map(fetchNamespaceAndChildren)
     )
-
-    // Sort children by shortName
-    const sortedChildren = children.sort((a, b) =>
-      a.shortName.localeCompare(b.shortName)
-    )
-
-    // Sort tables alphabetically
-    const sortedTables = (
-      tablesResponse.identifiers?.map((table) => table.name) || []
-    ).sort()
 
     return {
-      name: namespaceName,
-      shortName: (normalized || namespace)[
-        (normalized || namespace).length - 1
-      ],
-      tables: sortedTables,
-      children: sortedChildren,
+      name: parts.join("."),
+      shortName: parts[parts.length - 1],
+      tables: (
+        tablesResponse.identifiers?.map((table) => table.name) || []
+      ).sort(),
+      children: children.sort((a, b) => a.shortName.localeCompare(b.shortName)),
     }
   }
 
-  // Start with root namespaces
-  const response = await api.v1.listNamespaces()
-  const rootNamespaces = (response.namespaces || [])
-    .map((ns) => normalizeNamespaceParts(ns))
-    .filter((ns): ns is string[] => !!ns)
-
-  // Fetch all namespaces and their children
+  const rootNamespaces = await listChildNamespaces(api, [])
   const result = await Promise.all(
-    rootNamespaces.map((namespace) => fetchNamespaceAndChildren(namespace))
+    cleanNamespaces(rootNamespaces).map(fetchNamespaceAndChildren)
   )
-
-  // Sort root namespaces by shortName
   return result.sort((a, b) => a.shortName.localeCompare(b.shortName))
 }
 
@@ -161,31 +173,24 @@ export async function loadNamespaceChildren(
   parentNamespace?: string
 ): Promise<NamespaceChildren> {
   const api = catalogApi(catalog, isBrowser())
-  const trimmedParent = parentNamespace?.trim()
-
-  const namespacePromise = trimmedParent
-    ? api.v1.listNamespaces({ parent: trimmedParent })
-    : api.v1.listNamespaces()
+  const parentParts = namespaceParts(parentNamespace ?? "")
 
   // Tables exist only under a concrete namespace; root has no tables.
-  const tablesPromise = trimmedParent
-    ? api.v1.listTables(trimmedParent)
+  const tablesPromise = parentParts.length
+    ? api.v1.listTables(encodeNamespace(parentParts))
     : Promise.resolve({ identifiers: [] as Array<{ name: string }> })
 
-  const [namespaceResp, tablesResp] = await Promise.all([
-    namespacePromise,
+  const [childNamespaces, tablesResp] = await Promise.all([
+    listChildNamespaces(api, parentParts),
     tablesPromise,
   ])
 
-  const namespaces =
-    namespaceResp.namespaces
-      ?.map((ns) => (ns || []).map((p) => (p ?? "").trim()).filter(Boolean))
-      .filter((ns) => ns.length > 0)
-      .map((ns) => ({
-        name: ns.join("."),
-        shortName: ns[ns.length - 1],
-      }))
-      .sort((a, b) => a.shortName.localeCompare(b.shortName)) || []
+  const namespaces = cleanNamespaces(childNamespaces)
+    .map((ns) => ({
+      name: ns.join("."),
+      shortName: ns[ns.length - 1],
+    }))
+    .sort((a, b) => a.shortName.localeCompare(b.shortName))
 
   const tables =
     tablesResp.identifiers
@@ -247,8 +252,7 @@ export async function loadTableData(
   table: string
 ): Promise<LoadTableResult> {
   const api = catalogApi(catalog, isBrowser())
-  const response = await api.v1.loadTable(namespace, table)
-  return response
+  return api.v1.loadTable(encodeNamespace(namespaceParts(namespace)), table)
 }
 
 export async function dropTable(
@@ -257,7 +261,7 @@ export async function dropTable(
   table: string
 ): Promise<void> {
   const api = catalogApi(catalog)
-  await api.v1.dropTable(namespace, table)
+  await api.v1.dropTable(encodeNamespace(namespaceParts(namespace)), table)
 }
 
 export async function renameTable(
@@ -269,11 +273,11 @@ export async function renameTable(
   const api = catalogApi(catalog)
   await api.v1.renameTable({
     source: {
-      namespace: namespace.split("/"),
+      namespace: namespaceParts(namespace),
       name: sourceTable,
     },
     destination: {
-      namespace: namespace.split("/"),
+      namespace: namespaceParts(namespace),
       name: destinationTable,
     },
   })
@@ -287,7 +291,7 @@ export async function createNamespace(
   const api = catalogApi(catalog)
 
   // Split namespace by dots to create the namespace array
-  const namespaceArray = namespace.split(".")
+  const namespaceArray = namespaceParts(namespace)
 
   await api.v1.createNamespace({
     namespace: namespaceArray,
@@ -432,10 +436,11 @@ export async function getNamespaceTables(
   namespace: string
 ): Promise<NamespaceTable[]> {
   const api = catalogApi(catalog)
-  const response = await api.v1.listTables(namespace)
+  const encodedNamespace = encodeNamespace(namespaceParts(namespace))
+  const response = await api.v1.listTables(encodedNamespace)
   return (await Promise.all(
     response.identifiers?.map(async (table) => {
-      const tableResponse = await api.v1.loadTable(namespace, table.name)
+      const tableResponse = await api.v1.loadTable(encodedNamespace, table.name)
       return {
         name: table.name,
         formatVersion: tableResponse.metadata["format-version"] || "",
@@ -585,8 +590,13 @@ export async function fetchSampleData(
   table: string,
   pagination: PaginationParams
 ): Promise<FetchSampleDataResult> {
+  // Quote each part separately so nested namespaces resolve level by level.
+  const fullTableName = [catalog, ...namespaceParts(namespace), table]
+    .map((part) => `\`${part}\``)
+    .join(".")
+
   // First, get the total count of rows
-  const countQuery = `SELECT COUNT(*) as total FROM \`${catalog}\`.\`${namespace}\`.\`${table}\``
+  const countQuery = `SELECT COUNT(*) as total FROM ${fullTableName}`
   const countResult = await runQuery(countQuery)
 
   // Extract the total count from the result
@@ -598,7 +608,7 @@ export async function fetchSampleData(
   const offset = (pagination.page - 1) * pagination.pageSize
 
   // Construct the paginated query
-  const query = `SELECT * FROM \`${catalog}\`.\`${namespace}\`.\`${table}\` LIMIT ${pagination.pageSize} OFFSET ${offset}`
+  const query = `SELECT * FROM ${fullTableName} LIMIT ${pagination.pageSize} OFFSET ${offset}`
   const result = await runQuery(query)
 
   return {


### PR DESCRIPTION
## Problem

Tables and namespaces more than one level deep within a catalog were not visible from the Nimtable UI.

## Cause

This PR addresses two separate issues -
1. Frontend: nested namespaces sent via the HTTP request for `GET /v1/namespaces` were joined with `.` rather than `0x1F` (or `%1F` when url-encoded) which is the separator used in the Iceberg REST spec.
2. Backend: The `RESTCatalogAdapter` based on Iceberg test previously returned an empty list for non-paginated requests to `GET /v1/namespaces`, so child namespaces were never listed.

## Fix
1. In `src/lib/data-loader.ts` 
- encode namespaces according to the spec 
- add `pageSize` to the request
- fix `renameTable` which previously split namespace on `/`
2. In `RESTCatalogAdapter.java` 
- Use `CatalogHandlers.listNamespaces(catalog, ns)` for the non-paginated path (as is done in later versions of the upstream reference)
- Map blank `parent` to `Namespace.empty()` where previously splitting a blank string would produce `Namespace.of("")`
3. `useNamespaces.tsx` - flatten nested namespaces

## Compatibility Note

1. Namespaces containing a literal `.` are parsed as nested paths. Such namespaces were already problematic due to `createNamespace` splitting on literal `.` 

## Testing Details

Verified against a live Polaris catalog with 4-level nested namespaces in both the UI and via curl requests to the backend, specifying `parent=` with/without `pageSize`, and requests with blank parent.