### PR TITLE
Fix SQL editor CSV export serialization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Lint frontend
         run: pnpm run lint
 
+      - name: Test CSV serialization
+        run: pnpm run test:csv
+
       - name: Lint backend
         run: |
           cd backend

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test:csv": "tsx --test src/lib/csv.test.ts",
     "typecheck": "tsc --noEmit",
     "format:write": "prettier --write \"**/*.{ts,tsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache",

--- a/src/app/data/sql-editor/page.tsx
+++ b/src/app/data/sql-editor/page.tsx
@@ -42,6 +42,7 @@ import { useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
 import { runQuery } from "@/lib/data-loader"
+import { rowsToCsv } from "@/lib/csv"
 import { errorToString } from "@/lib/utils"
 
 export default function SQLEditorPage() {
@@ -166,18 +167,7 @@ export default function SQLEditorPage() {
   const handleDownloadResults = () => {
     if (!queryResults) return
 
-    // Create CSV content
-    const headers = queryResults.columns.join(",")
-    const rows = queryResults.rows
-      .map((row) =>
-        row
-          .map((cell) =>
-            typeof cell === "string" ? `"${cell.replace(/"/g, '""')}"` : cell
-          )
-          .join(",")
-      )
-      .join("\n")
-    const csvContent = `${headers}\n${rows}`
+    const csvContent = rowsToCsv(queryResults.columns, queryResults.rows)
 
     // Create download link
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { rowsToCsv, serializeCsvCell } from "./csv"
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = []
+  let current = ""
+  let inQuotes = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    const nextChar = line[index + 1]
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        current += '"'
+        index += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+      continue
+    }
+
+    if (char === "," && !inQuotes) {
+      cells.push(current)
+      current = ""
+      continue
+    }
+
+    current += char
+  }
+
+  cells.push(current)
+  return cells
+}
+
+describe("serializeCsvCell", () => {
+  it("escapes strings that contain CSV control characters", () => {
+    assert.equal(serializeCsvCell("plain"), "plain")
+    assert.equal(serializeCsvCell("hello,world"), '"hello,world"')
+    assert.equal(serializeCsvCell('hello "world"'), '"hello ""world"""')
+    assert.equal(serializeCsvCell("hello\nworld"), '"hello\nworld"')
+  })
+
+  it("serializes scalar nullish values", () => {
+    assert.equal(serializeCsvCell(null), "")
+    assert.equal(serializeCsvCell(undefined), "")
+    assert.equal(serializeCsvCell(123), "123")
+    assert.equal(serializeCsvCell(true), "true")
+  })
+
+  it("formats timestamp arrays without timezone conversion", () => {
+    assert.equal(
+      serializeCsvCell([2026, 7, 11, 15, 54, 42]),
+      "2026-07-11 15:54:42"
+    )
+    assert.equal(serializeCsvCell([2026, 7, 12, 0, 8]), "2026-07-12 00:08:00")
+    assert.equal(
+      serializeCsvCell([2026, 7, 12, 20, 4, 18, 546000000]),
+      "2026-07-12 20:04:18.546000000"
+    )
+  })
+
+  it("keeps non-timestamp arrays and objects in one CSV cell", () => {
+    assert.equal(serializeCsvCell(["a", "b"]), '"[""a"",""b""]"')
+    assert.equal(serializeCsvCell({ a: 1, b: 2 }), '"{""a"":1,""b"":2}"')
+  })
+})
+
+describe("rowsToCsv", () => {
+  it("keeps timestamp values within the expected column count", () => {
+    const columns = [
+      "dn_request_id",
+      "request_timestamp",
+      "request_kind_id",
+      "request_kind_id_2",
+      "facility_id",
+      "body_part",
+      "body_part_2",
+      "body_part_3",
+      "note",
+      "center_comment",
+      "doctor_comment",
+      "report_request",
+      "report_text",
+      "report_impression",
+      "report_comment",
+      "s3_object_key",
+      "s3_object_size",
+      "created_at",
+      "updated_at",
+    ]
+    const rows = [
+      [
+        "REQ-0001",
+        [2026, 7, 11, 15, 54, 42],
+        0,
+        -1,
+        7023,
+        "Chest",
+        "",
+        "",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        "uploads/example.zip",
+        132606948,
+        [2026, 7, 12, 20, 4, 18, 546000000],
+        [2026, 7, 12, 20, 4, 18, 546000000],
+      ],
+    ]
+
+    const csv = rowsToCsv(columns, rows)
+    const [, dataLine] = csv.split("\n")
+
+    assert.equal(parseCsvLine(dataLine).length, columns.length)
+  })
+})

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function escapeCsvText(text: string): string {
+  const escaped = text.replace(/"/g, '""')
+  return /[",\r\n]/.test(escaped) ? `"${escaped}"` : escaped
+}
+
+function isIntegerInRange(
+  value: unknown,
+  min: number,
+  max: number
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= min &&
+    value <= max
+  )
+}
+
+function isTimestampArray(value: unknown[]): value is number[] {
+  if (value.length < 5 || value.length > 7) return false
+  if (!value.every(Number.isInteger)) return false
+
+  const [year, month, day, hour, minute, second = 0, nano = 0] = value
+
+  return (
+    isIntegerInRange(year, 1000, 9999) &&
+    isIntegerInRange(month, 1, 12) &&
+    isIntegerInRange(day, 1, 31) &&
+    isIntegerInRange(hour, 0, 23) &&
+    isIntegerInRange(minute, 0, 59) &&
+    isIntegerInRange(second, 0, 59) &&
+    isIntegerInRange(nano, 0, 999999999)
+  )
+}
+
+function padDatePart(value: number, length = 2): string {
+  return String(value).padStart(length, "0")
+}
+
+function formatTimestampArray(value: number[]): string {
+  const [year, month, day, hour, minute, second = 0, nano = 0] = value
+  const timestamp =
+    `${padDatePart(year, 4)}-${padDatePart(month)}-${padDatePart(day)} ` +
+    `${padDatePart(hour)}:${padDatePart(minute)}:${padDatePart(second)}`
+
+  return nano > 0 ? `${timestamp}.${padDatePart(nano, 9)}` : timestamp
+}
+
+function stringifyComplexCsvValue(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+export function serializeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return ""
+
+  if (typeof value === "string") return escapeCsvText(value)
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    if (isTimestampArray(value)) {
+      return escapeCsvText(formatTimestampArray(value))
+    }
+
+    return escapeCsvText(stringifyComplexCsvValue(value))
+  }
+
+  return escapeCsvText(stringifyComplexCsvValue(value))
+}
+
+export function rowsToCsv(columns: string[], rows: unknown[][]): string {
+  const headers = columns.map(serializeCsvCell).join(",")
+  const csvRows = rows
+    .map((row) =>
+      columns.map((_, index) => serializeCsvCell(row[index])).join(",")
+    )
+    .join("\n")
+
+  return `${headers}\n${csvRows}`
+}


### PR DESCRIPTION
## Summary
- serialize SQL editor CSV cells through a shared helper instead of relying on Array.toString()
- format Jackson-style timestamp arrays as single timestamp values without timezone conversion
- quote JSON-serialized arrays/objects so nested values cannot add extra CSV columns
- add a focused CSV regression test and run it in the PR build workflow

## Testing
- pnpm run test:csv
- pnpm run format:check
- pnpm run lint (passes with existing warnings in src/components/onboarding/LocalCatalogWizardModal.tsx)
- pnpm prisma generate
- pnpm run typecheck
- pnpm run build
- JAVA_HOME=JDK17 ./gradlew spotlessCheck