### PR TITLE
docs: replace broken Slack community link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: 💬 Slack Community
-    url: https://go.nimtable.com/slack
-    about: Join our Slack workspace for real-time help, discussions, and community support
+  - name: 💬 GitHub Discussions
+    url: https://github.com/nimtable/nimtable/discussions
+    about: Ask questions and connect with the Nimtable community

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
     />
   </a>
   <a
-    href="https://go.risingwave.com/slack"
+    href="https://github.com/nimtable/nimtable/discussions"
     target="_blank"
   >
-    <img alt="Slack" src="https://badgen.net/badge/Slack/Join%20Community%20(Powered%20By%20RisingWave%20Labs)/0abd59?icon=slack" />
+    <img alt="GitHub Discussions" src="https://badgen.net/badge/GitHub/Join%20Discussions/24292f?icon=github" />
   </a>
 </div>
 


### PR DESCRIPTION
## Summary

- replace the broken README Slack badge target with Nimtable GitHub Discussions
- update the issue-template community contact to the same repository-owned destination
- avoid depending on an unconfigured or expiring Slack short link

## Validation

- YAML syntax and expected contact URL validated with Ruby Psych
- pnpm dlx prettier@3.5.3 --check .github/ISSUE_TEMPLATE/config.yml
- git diff --check
- confirmed the Nimtable Discussions API returns the open welcome discussion
- confirmed no stale Slack URL remains in README.md or .github/ISSUE_TEMPLATE/config.yml

Closes #240