### PR TITLE
feat(ci): publish versioned Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
-name: Publish Nightly Docker Image
+name: Publish Docker Image
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   schedule:
     - cron: '0 17 * * *'
   # Allow manual trigger
@@ -48,9 +51,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.image_config.image_name }}
+          flavor: |
+            latest=false
           tags: |
-            type=raw,value=nightly-${{matrix.arch_config.arch}}
-            type=raw,value=nightly-${{ github.sha }}-${{matrix.arch_config.arch}}
+            type=raw,value=nightly-${{matrix.arch_config.arch}},enable=${{ github.event_name != 'push' }}
+            type=raw,value=nightly-${{ github.sha }}-${{matrix.arch_config.arch}},enable=${{ github.event_name != 'push' }}
+            type=semver,pattern={{version}},suffix=-${{matrix.arch_config.arch}}
 
       - name: Build and push Docker image (${{ matrix.image_config.type }})
         uses: docker/build-push-action@v6
@@ -75,27 +81,55 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract release version
+        if: github.event_name == 'push'
+        id: release-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
       - name: Create and push manifest images (nightly)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.IMAGE_NAME }}:nightly
           images: ${{ env.IMAGE_NAME }}:nightly-amd64,${{ env.IMAGE_NAME }}:nightly-arm64
           push: true
       - name: Create and push manifest images (nightly-sha)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.IMAGE_NAME }}:nightly-${{ github.sha }}
           images: ${{ env.IMAGE_NAME }}:nightly-${{ github.sha }}-amd64,${{ env.IMAGE_NAME }}:nightly-${{ github.sha }}-arm64
           push: true
       - name: Create and push manifest images for Frontend (nightly)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.FRONTEND_IMAGE_NAME }}:nightly
           images: ${{ env.FRONTEND_IMAGE_NAME }}:nightly-amd64,${{ env.FRONTEND_IMAGE_NAME }}:nightly-arm64
           push: true
       - name: Create and push manifest images for Frontend (nightly-sha)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}
           images: ${{ env.FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}-amd64,${{ env.FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}-arm64
+          push: true
+      - name: Create and push manifest images (release)
+        if: github.event_name == 'push'
+        uses: Noelware/docker-manifest-action@0.4.3
+        with:
+          inputs: ${{ env.IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}
+          images: ${{ env.IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-amd64,${{ env.IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-arm64
+          push: true
+      - name: Create and push manifest images for Frontend (release)
+        if: github.event_name == 'push'
+        uses: Noelware/docker-manifest-action@0.4.3
+        with:
+          inputs: ${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}
+          images: ${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-amd64,${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-arm64
           push: true

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,6 +1,9 @@
-name: Publish Nightly DockerHub Image
+name: Publish DockerHub Image
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   schedule:
     - cron: '0 17 * * *'
   # Allow manual trigger
@@ -46,9 +49,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.image_config.type == 'backend' && env.DOCKERHUB_IMAGE_NAME || env.DOCKERHUB_FRONTEND_IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
-            type=raw,value=nightly-${{matrix.arch_config.arch}}
-            type=raw,value=nightly-${{ github.sha }}-${{matrix.arch_config.arch}}
+            type=raw,value=nightly-${{matrix.arch_config.arch}},enable=${{ github.event_name != 'push' }}
+            type=raw,value=nightly-${{ github.sha }}-${{matrix.arch_config.arch}},enable=${{ github.event_name != 'push' }}
+            type=semver,pattern={{version}},suffix=-${{matrix.arch_config.arch}}
 
       - name: Build and push Docker image (${{ matrix.image_config.type }})
         uses: docker/build-push-action@v6
@@ -73,7 +79,18 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract release version
+        if: github.event_name == 'push'
+        id: release-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
       - name: Create and push manifest images to DockerHub (nightly)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.DOCKERHUB_IMAGE_NAME }}:nightly
@@ -81,6 +98,7 @@ jobs:
           amend: true
           push: true
       - name: Create and push manifest images to DockerHub (nightly-sha)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.DOCKERHUB_IMAGE_NAME }}:nightly-${{ github.sha }}
@@ -88,6 +106,7 @@ jobs:
           amend: true
           push: true
       - name: Create and push manifest images for Frontend to DockerHub (nightly)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:nightly
@@ -95,10 +114,26 @@ jobs:
           amend: true
           push: true
       - name: Create and push manifest images for Frontend to DockerHub (nightly-sha)
+        if: github.event_name != 'push'
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}
           images: ${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}-amd64,${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:nightly-${{ github.sha }}-arm64
           amend: true
           push: true
-
+      - name: Create and push manifest images to DockerHub (release)
+        if: github.event_name == 'push'
+        uses: Noelware/docker-manifest-action@0.4.3
+        with:
+          inputs: ${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}
+          images: ${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-amd64,${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-arm64
+          amend: true
+          push: true
+      - name: Create and push manifest images for Frontend to DockerHub (release)
+        if: github.event_name == 'push'
+        uses: Noelware/docker-manifest-action@0.4.3
+        with:
+          inputs: ${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}
+          images: ${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-amd64,${{ env.DOCKERHUB_FRONTEND_IMAGE_NAME }}:${{ steps.release-meta.outputs.version }}-arm64
+          amend: true
+          push: true


### PR DESCRIPTION
## Summary

- run the GHCR and DockerHub publish workflows for `v*.*.*` tag pushes
- publish architecture-specific release images and merge them into normalized version tags such as `0.1.0` for both `nimtable` and `nimtable-web`
- keep scheduled and manually dispatched builds on the existing nightly tags, without implicitly adding a `latest` release tag

## Validation

- `actionlint .github/workflows/docker.yml .github/workflows/dockerhub.yml`
- parsed both modified YAML workflows with Ruby Psych and asserted the version trigger, architecture-specific semver tags, and merged release-version outputs
- `git diff --check`

Closes #238
