### PR TITLE
fix: quote optimization table identifiers

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -125,8 +125,14 @@ dependencies {
   implementation 'org.slf4j:slf4j-api:2.0.12'
   implementation 'ch.qos.logback:logback-classic:1.5.8'
 
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
+
   // Password Hashing
   implementation 'org.mindrot:jbcrypt:0.4'
+}
+
+test {
+  useJUnitPlatform()
 }
 
 jar {

--- a/backend/src/main/java/io/nimtable/OptimizeServlet.java
+++ b/backend/src/main/java/io/nimtable/OptimizeServlet.java
@@ -23,6 +23,7 @@ import io.nimtable.db.repository.CatalogRepository;
 import io.nimtable.db.repository.ScheduledTaskRepository;
 import io.nimtable.spark.LocalSpark;
 import io.nimtable.util.CronUtil;
+import io.nimtable.util.SparkSqlUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -92,8 +93,8 @@ public class OptimizeServlet extends HttpServlet {
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(
                 String.format(
-                        "CALL `%s`.system.rewrite_data_files(table => '%s.%s'",
-                        catalogName, namespace, tableName));
+                        "CALL `%s`.system.rewrite_data_files(table => %s",
+                        catalogName, SparkSqlUtil.tableIdentifierArgument(namespace, tableName)));
 
         if (strategy != null && !strategy.isEmpty()) {
             sqlBuilder.append(String.format(", strategy => '%s'", strategy));
@@ -139,8 +140,11 @@ public class OptimizeServlet extends HttpServlet {
                 Instant.ofEpochMilli(System.currentTimeMillis() - maxSnapshotAgeMs).toString();
         String sql =
                 String.format(
-                        "CALL `%s`.system.expire_snapshots(table => '%s.%s', older_than => TIMESTAMP '%s', retain_last => %d)",
-                        catalogName, namespace, tableName, timestampStr, minSnapshotsToKeep);
+                        "CALL `%s`.system.expire_snapshots(table => %s, older_than => TIMESTAMP '%s', retain_last => %d)",
+                        catalogName,
+                        SparkSqlUtil.tableIdentifierArgument(namespace, tableName),
+                        timestampStr,
+                        minSnapshotsToKeep);
         logger.info("Executing expire snapshots SQL: {}", sql);
         Row result = spark.sql(sql).collectAsList().get(0);
 
@@ -163,8 +167,10 @@ public class OptimizeServlet extends HttpServlet {
                 Instant.ofEpochMilli(System.currentTimeMillis() - olderThanMs).toString();
         String sql =
                 String.format(
-                        "CALL `%s`.system.remove_orphan_files(table => '%s.%s', older_than => TIMESTAMP '%s')",
-                        catalogName, namespace, tableName, timestampStr);
+                        "CALL `%s`.system.remove_orphan_files(table => %s, older_than => TIMESTAMP '%s')",
+                        catalogName,
+                        SparkSqlUtil.tableIdentifierArgument(namespace, tableName),
+                        timestampStr);
         logger.info("Executing remove orphan files SQL: {}", sql);
         List<Row> result = spark.sql(sql).collectAsList();
         return new CleanOrphanFilesResult(

--- a/backend/src/main/java/io/nimtable/schedule/ScheduleManager.java
+++ b/backend/src/main/java/io/nimtable/schedule/ScheduleManager.java
@@ -22,6 +22,7 @@ import io.nimtable.db.repository.CatalogRepository;
 import io.nimtable.db.repository.ScheduledTaskRepository;
 import io.nimtable.spark.LocalSpark;
 import io.nimtable.util.CronUtil;
+import io.nimtable.util.SparkSqlUtil;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -239,8 +240,10 @@ public class ScheduleManager {
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(
                 String.format(
-                        "CALL `%s`.system.rewrite_data_files(table => '%s.%s'",
-                        task.getCatalogName(), task.getNamespace(), task.getTableName()));
+                        "CALL `%s`.system.rewrite_data_files(table => %s",
+                        task.getCatalogName(),
+                        SparkSqlUtil.tableIdentifierArgument(
+                                task.getNamespace(), task.getTableName())));
 
         if (task.getStrategy() != null && !task.getStrategy().isEmpty()) {
             sqlBuilder.append(String.format(", strategy => '%s'", task.getStrategy()));
@@ -277,10 +280,10 @@ public class ScheduleManager {
 
         String sql =
                 String.format(
-                        "CALL `%s`.system.expire_snapshots(table => '%s.%s', older_than => TIMESTAMP '%s', retain_last => %d)",
+                        "CALL `%s`.system.expire_snapshots(table => %s, older_than => TIMESTAMP '%s', retain_last => %d)",
                         task.getCatalogName(),
-                        task.getNamespace(),
-                        task.getTableName(),
+                        SparkSqlUtil.tableIdentifierArgument(
+                                task.getNamespace(), task.getTableName()),
                         timestampStr,
                         task.getMinSnapshotsToKeep());
 
@@ -300,10 +303,10 @@ public class ScheduleManager {
 
         String sql =
                 String.format(
-                        "CALL `%s`.system.remove_orphan_files(table => '%s.%s', older_than => TIMESTAMP '%s')",
+                        "CALL `%s`.system.remove_orphan_files(table => %s, older_than => TIMESTAMP '%s')",
                         task.getCatalogName(),
-                        task.getNamespace(),
-                        task.getTableName(),
+                        SparkSqlUtil.tableIdentifierArgument(
+                                task.getNamespace(), task.getTableName()),
                         timestampStr);
 
         LOG.info("Executing orphan file cleanup SQL: {}", sql);

--- a/backend/src/main/java/io/nimtable/util/SparkSqlUtil.java
+++ b/backend/src/main/java/io/nimtable/util/SparkSqlUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.util;
+
+/** Utilities for safely embedding identifiers in Spark SQL statements. */
+public final class SparkSqlUtil {
+    private SparkSqlUtil() {}
+
+    /** Returns a SQL string literal containing a quoted two-part table identifier. */
+    public static String tableIdentifierArgument(String namespace, String tableName) {
+        String tableIdentifier = quoteIdentifier(namespace) + "." + quoteIdentifier(tableName);
+        return "'" + tableIdentifier.replace("'", "''") + "'";
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+}

--- a/backend/src/test/java/io/nimtable/util/SparkSqlUtilTest.java
+++ b/backend/src/test/java/io/nimtable/util/SparkSqlUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SparkSqlUtilTest {
+    @Test
+    void quotesNumericNamespace() {
+        assertEquals("'`12345`.`orders`'", SparkSqlUtil.tableIdentifierArgument("12345", "orders"));
+    }
+
+    @Test
+    void quotesSpecialCharactersAndEscapesSqlLiteral() {
+        assertEquals(
+                "'`sales.region`.`order``s''archive`'",
+                SparkSqlUtil.tableIdentifierArgument("sales.region", "order`s'archive"));
+    }
+}


### PR DESCRIPTION
## Summary

- quote namespace and table components in Spark procedure table arguments
- use the shared argument builder for immediate and scheduled maintenance operations
- add regression coverage for numeric namespaces and escaped special characters

## Validation

- `./gradlew test spotlessCheck` (2 tests, 0 failures/errors)
- `./gradlew build -x spotlessCheck`

Closes #243