### PR TITLE
feat(helm): add Kubernetes deployment chart

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,34 @@
+name: Helm
+
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: Lint chart
+        run: helm lint charts/nimtable --strict
+      - name: Render default installation
+        run: helm template nimtable charts/nimtable
+      - name: Render external database and ingress installation
+        run: >-
+          helm template nimtable charts/nimtable
+          --set postgresql.enabled=false
+          --set externalDatabase.host=postgres.example.com
+          --set-string externalDatabase.password=test-password
+          --set ingress.enabled=true

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ docker compose up -d
 
 Access the UI at [http://localhost:3000](http://localhost:3000).
 
+To deploy on Kubernetes, use the included [Helm chart](charts/nimtable):
+
+```bash
+helm install nimtable ./charts/nimtable
+```
+
+See the [chart documentation](charts/nimtable/README.md) for credential,
+external database, persistence, and ingress configuration.
+
 #### Default Admin Login
 
 - **Username:** `admin`

--- a/charts/nimtable/Chart.yaml
+++ b/charts/nimtable/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: nimtable
+description: A Helm chart for Nimtable, an observability platform for Apache Iceberg
+type: application
+version: 0.1.0
+appVersion: nightly
+home: https://github.com/nimtable/nimtable
+icon: https://raw.githubusercontent.com/nimtable/nimtable/main/public/nimtable_icon.png
+sources:
+  - https://github.com/nimtable/nimtable
+maintainers:
+  - name: Nimtable maintainers
+    url: https://github.com/nimtable/nimtable

--- a/charts/nimtable/README.md
+++ b/charts/nimtable/README.md
@@ -1,0 +1,65 @@
+# Nimtable Helm chart
+
+This chart deploys the Nimtable web application, backend, and (by default) a
+single PostgreSQL StatefulSet.
+
+## Install
+
+Choose non-default credentials and install the chart:
+
+```bash
+helm install nimtable ./charts/nimtable \
+  --set-string auth.jwtSecret='replace-with-a-long-random-value' \
+  --set-string auth.adminPassword='replace-with-a-strong-password' \
+  --set-string postgresql.auth.password='replace-with-a-strong-password'
+```
+
+Wait for the deployments and access the web service:
+
+```bash
+kubectl rollout status deployment/nimtable-backend
+kubectl rollout status deployment/nimtable-web
+kubectl port-forward service/nimtable-web 3000:3000
+```
+
+Open <http://localhost:3000> and sign in with the configured admin credentials.
+
+## Use an external PostgreSQL database
+
+Disable the bundled StatefulSet and configure the external server:
+
+```bash
+helm install nimtable ./charts/nimtable \
+  --set postgresql.enabled=false \
+  --set externalDatabase.host=postgres.example.com \
+  --set externalDatabase.username=nimtable \
+  --set-string externalDatabase.password='replace-with-a-strong-password' \
+  --set externalDatabase.database=nimtable \
+  --set-string auth.jwtSecret='replace-with-a-long-random-value' \
+  --set-string auth.adminPassword='replace-with-a-strong-password'
+```
+
+The database must already exist and be reachable from both Nimtable
+deployments. Nimtable runs its own schema migrations when it starts.
+
+## Configuration
+
+| Value | Description | Default |
+| --- | --- | --- |
+| `web.image.repository` | Web image repository | `ghcr.io/nimtable/nimtable-web` |
+| `web.image.tag` | Web image tag; defaults to `appVersion` | `""` |
+| `backend.image.repository` | Backend image repository | `ghcr.io/nimtable/nimtable` |
+| `backend.image.tag` | Backend image tag; defaults to `appVersion` | `""` |
+| `backend.catalogs` | Catalog entries written to the backend `config.yaml` | `[]` |
+| `auth.jwtSecret` | Secret used to sign login tokens | `change-me` |
+| `auth.adminUsername` | Initial administrator username | `admin` |
+| `auth.adminPassword` | Initial administrator password | `admin` |
+| `postgresql.enabled` | Deploy the bundled PostgreSQL StatefulSet | `true` |
+| `postgresql.persistence.enabled` | Persist the bundled database | `true` |
+| `postgresql.persistence.size` | Database volume size | `8Gi` |
+| `externalDatabase.*` | External database connection settings | See `values.yaml` |
+| `ingress.enabled` | Create an Ingress for the web service | `false` |
+
+See [`values.yaml`](values.yaml) for the complete set of values. Credentials
+are stored in a Kubernetes Secret, but Helm values themselves are not encrypted;
+use your cluster's normal secret-management workflow for production releases.

--- a/charts/nimtable/templates/NOTES.txt
+++ b/charts/nimtable/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Wait for the Nimtable workloads to become ready:
+
+   kubectl rollout status deployment/{{ include "nimtable.backendName" . }}
+   kubectl rollout status deployment/{{ include "nimtable.webName" . }}
+
+{{- if .Values.ingress.enabled }}
+2. Open the URL configured under ingress.hosts.
+{{- else }}
+2. Forward the web service locally:
+
+   kubectl port-forward service/{{ include "nimtable.webName" . }} 3000:{{ .Values.web.service.port }}
+
+   Then open http://localhost:3000.
+{{- end }}
+
+The default login is admin/admin unless auth.adminUsername and auth.adminPassword were changed.
+Change all auth and database credentials before exposing this installation.

--- a/charts/nimtable/templates/_helpers.tpl
+++ b/charts/nimtable/templates/_helpers.tpl
@@ -1,0 +1,102 @@
+{{/* Expand the chart name. */}}
+{{- define "nimtable.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a release-qualified name. */}}
+{{- define "nimtable.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "nimtable.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "nimtable.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels for a component. Expects a dict with root and component. */}}
+{{- define "nimtable.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nimtable.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "nimtable.webName" -}}
+{{- printf "%s-web" (include "nimtable.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nimtable.backendName" -}}
+{{- printf "%s-backend" (include "nimtable.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nimtable.postgresqlName" -}}
+{{- printf "%s-postgresql" (include "nimtable.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nimtable.secretName" -}}
+{{- printf "%s-config" (include "nimtable.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "nimtable.imageTag" -}}
+{{- default .Chart.AppVersion .tag }}
+{{- end }}
+
+{{- define "nimtable.databaseHost" -}}
+{{- if .Values.postgresql.enabled }}
+{{- include "nimtable.postgresqlName" . }}
+{{- else }}
+{{- required "externalDatabase.host is required when postgresql.enabled is false" .Values.externalDatabase.host }}
+{{- end }}
+{{- end }}
+
+{{- define "nimtable.databasePort" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.service.port }}
+{{- else }}
+{{- .Values.externalDatabase.port }}
+{{- end }}
+{{- end }}
+
+{{- define "nimtable.databaseUsername" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.username }}
+{{- else }}
+{{- .Values.externalDatabase.username }}
+{{- end }}
+{{- end }}
+
+{{- define "nimtable.databasePassword" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.password }}
+{{- else }}
+{{- .Values.externalDatabase.password }}
+{{- end }}
+{{- end }}
+
+{{- define "nimtable.databaseName" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.database }}
+{{- else }}
+{{- .Values.externalDatabase.database }}
+{{- end }}
+{{- end }}
+
+{{- define "nimtable.databaseUrl" -}}
+{{- printf "postgresql://%s:%s@%s:%v/%s" (include "nimtable.databaseUsername" . | urlquery) (include "nimtable.databasePassword" . | urlquery) (include "nimtable.databaseHost" .) (include "nimtable.databasePort" .) (include "nimtable.databaseName" . | urlquery) }}
+{{- end }}
+
+{{- define "nimtable.databaseJdbcUrl" -}}
+{{- printf "jdbc:postgresql://%s:%v/%s" (include "nimtable.databaseHost" .) (include "nimtable.databasePort" .) (include "nimtable.databaseName" .) }}
+{{- end }}

--- a/charts/nimtable/templates/backend-deployment.yaml
+++ b/charts/nimtable/templates/backend-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nimtable.backendName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nimtable.selectorLabels" (dict "root" . "component" "backend") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "nimtable.selectorLabels" (dict "root" . "component" "backend") | nindent 8 }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ include "nimtable.imageTag" (dict "tag" .Values.backend.image.tag "Chart" .Chart) }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.backend.javaOpts | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.service.port }}
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+          volumeMounts:
+            - name: config
+              mountPath: /nimtable/config.yaml
+              subPath: config.yaml
+              readOnly: true
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "nimtable.secretName" . }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nimtable/templates/backend-service.yaml
+++ b/charts/nimtable/templates/backend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nimtable.backendName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "nimtable.selectorLabels" (dict "root" . "component" "backend") | nindent 4 }}

--- a/charts/nimtable/templates/ingress.yaml
+++ b/charts/nimtable/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "nimtable.fullname" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "nimtable.webName" $ }}
+                port:
+                  number: {{ $.Values.web.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/nimtable/templates/postgresql-service.yaml
+++ b/charts/nimtable/templates/postgresql-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nimtable.postgresqlName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  ports:
+    - name: postgresql
+      port: {{ .Values.postgresql.service.port }}
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    {{- include "nimtable.selectorLabels" (dict "root" . "component" "postgresql") | nindent 4 }}
+{{- end }}

--- a/charts/nimtable/templates/postgresql-statefulset.yaml
+++ b/charts/nimtable/templates/postgresql-statefulset.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nimtable.postgresqlName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "nimtable.postgresqlName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "nimtable.selectorLabels" (dict "root" . "component" "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "nimtable.selectorLabels" (dict "root" . "component" "postgresql") | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: database-username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: database-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: database-name
+          ports:
+            - name: postgresql
+              containerPort: {{ .Values.postgresql.service.port }}
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if not .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/nimtable/templates/secret.yaml
+++ b/charts/nimtable/templates/secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nimtable.secretName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-url: {{ include "nimtable.databaseUrl" . | quote }}
+  database-username: {{ include "nimtable.databaseUsername" . | quote }}
+  database-password: {{ include "nimtable.databasePassword" . | quote }}
+  database-name: {{ include "nimtable.databaseName" . | quote }}
+  jwt-secret: {{ required "auth.jwtSecret is required" .Values.auth.jwtSecret | quote }}
+  admin-username: {{ required "auth.adminUsername is required" .Values.auth.adminUsername | quote }}
+  admin-password: {{ required "auth.adminPassword is required" .Values.auth.adminPassword | quote }}
+  config.yaml: |
+    server:
+      port: {{ .Values.backend.service.port }}
+      host: 0.0.0.0
+    database:
+      url: {{ include "nimtable.databaseJdbcUrl" . }}
+      username: {{ include "nimtable.databaseUsername" . | quote }}
+      password: {{ include "nimtable.databasePassword" . | quote }}
+    {{- with .Values.backend.catalogs }}
+    catalogs:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/charts/nimtable/templates/tests/test-connection.yaml
+++ b/charts/nimtable/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nimtable.fullname" . }}-test-connection"
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.37
+      command:
+        - wget
+      args:
+        - "{{ include "nimtable.webName" . }}:{{ .Values.web.service.port }}"

--- a/charts/nimtable/templates/web-deployment.yaml
+++ b/charts/nimtable/templates/web-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nimtable.webName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nimtable.selectorLabels" (dict "root" . "component" "web") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "nimtable.selectorLabels" (dict "root" . "component" "web") | nindent 8 }}
+        {{- with .Values.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ include "nimtable.imageTag" (dict "tag" .Values.web.image.tag "Chart" .Chart) }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          env:
+            - name: JAVA_API_URL
+              value: "http://{{ include "nimtable.backendName" . }}:{{ .Values.backend.service.port }}"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: database-url
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: jwt-secret
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: admin-username
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nimtable.secretName" . }}
+                  key: admin-password
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.service.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nimtable/templates/web-service.yaml
+++ b/charts/nimtable/templates/web-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nimtable.webName" . }}
+  labels:
+    {{- include "nimtable.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "nimtable.selectorLabels" (dict "root" . "component" "web") | nindent 4 }}

--- a/charts/nimtable/values.yaml
+++ b/charts/nimtable/values.yaml
@@ -1,0 +1,86 @@
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+web:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/nimtable/nimtable-web
+    pullPolicy: IfNotPresent
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 3000
+  podAnnotations: {}
+  podLabels: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+backend:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/nimtable/nimtable
+    pullPolicy: IfNotPresent
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 8182
+  javaOpts: -Xmx2g -Xms512m
+  catalogs: []
+  podAnnotations: {}
+  podLabels: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+auth:
+  # Change these values before exposing Nimtable outside a trusted environment.
+  jwtSecret: change-me
+  adminUsername: admin
+  adminPassword: admin
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    pullPolicy: IfNotPresent
+    tag: "17"
+  auth:
+    username: nimtable_user
+    password: password
+    database: nimtable
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+    storageClass: ""
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Used when postgresql.enabled is false.
+externalDatabase:
+  host: ""
+  port: 5432
+  username: nimtable_user
+  password: ""
+  database: nimtable
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: nimtable.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []


### PR DESCRIPTION
## Summary

- add a Helm chart for the Nimtable web and backend services with a persistent PostgreSQL StatefulSet
- support external PostgreSQL, custom catalog configuration, ingress, image/resource/scheduling overrides, probes, and a Helm connection test
- document installation and add CI coverage for default and external-database renders

## Validation

- `helm lint charts/nimtable --strict`
- `helm lint charts/nimtable --strict --set postgresql.enabled=false --set externalDatabase.host=postgres.example.com --set-string externalDatabase.password=test-password --set ingress.enabled=true`
- `helm template` for default, external database + ingress, and configured catalog scenarios
- `kubeconform -strict`: 8/8 default resources, 7/7 external-database resources, and 8/8 catalog resources valid
- `actionlint .github/workflows/helm.yml`
- `helm package charts/nimtable --destination /tmp`
- `git diff --check`

Closes #239