### PR TITLE
fix(optimization): preserve backend error details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check frontend formatting
         run: pnpm run format:check
 
+      - name: Test frontend
+        run: pnpm test
+
       - name: Lint frontend
         run: pnpm run lint
 

--- a/backend/src/main/java/io/nimtable/OptimizeServlet.java
+++ b/backend/src/main/java/io/nimtable/OptimizeServlet.java
@@ -278,8 +278,8 @@ public class OptimizeServlet extends HttpServlet {
         switch (operation) {
             case "compact":
                 if (compaction) {
-                    SparkSession spark = LocalSpark.getInstance(config).getSpark();
                     try {
+                        SparkSession spark = LocalSpark.getInstance(config).getSpark();
                         CompactionResult compactionResult =
                                 compactTable(
                                         spark,
@@ -314,8 +314,8 @@ public class OptimizeServlet extends HttpServlet {
 
             case "expire-snapshots":
                 if (snapshotRetention) {
-                    SparkSession spark = LocalSpark.getInstance(config).getSpark();
                     try {
+                        SparkSession spark = LocalSpark.getInstance(config).getSpark();
                         ExpireSnapshotResult expireResult =
                                 expireSnapshots(
                                         spark,
@@ -348,8 +348,8 @@ public class OptimizeServlet extends HttpServlet {
 
             case "clean-orphan-files":
                 if (orphanFileDeletion) {
-                    SparkSession spark = LocalSpark.getInstance(config).getSpark();
                     try {
+                        SparkSession spark = LocalSpark.getInstance(config).getSpark();
                         CleanOrphanFilesResult cleanResult =
                                 cleanOrphanFiles(
                                         spark,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "node --import tsx --test src/lib/*.test.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",

--- a/src/lib/data-loader.ts
+++ b/src/lib/data-loader.ts
@@ -20,6 +20,7 @@ import { CatalogConfig, LoadTableResult, PartitionSpec } from "./api"
 import { getCatalogs } from "./client"
 import { createClient, createConfig } from "@hey-api/client-fetch"
 import { getApiBaseUrl } from "./api-config"
+import { readOptimizationResponse } from "./optimization-response"
 
 // Re-export types from api.ts, ensuring application code don't need to access the api directly.
 export type {
@@ -559,12 +560,7 @@ export async function runOptimizationOperation(
     }
   )
 
-  if (!response.ok) {
-    const error = await response.json()
-    throw new Error(error.message || `Failed to run ${step}`)
-  }
-
-  return await response.json()
+  return await readOptimizationResponse(response, step)
 }
 
 export interface PaginationParams {

--- a/src/lib/optimization-response.test.ts
+++ b/src/lib/optimization-response.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { readOptimizationResponse } from "./optimization-response"
+
+test("returns a successful JSON response", async () => {
+  const response = new Response('{"rewrittenDataFilesCount":2}')
+
+  assert.deepEqual(await readOptimizationResponse(response, "Compaction"), {
+    rewrittenDataFilesCount: 2,
+  })
+})
+
+test("preserves a JSON error message", async () => {
+  const response = new Response(
+    '{"message":"Polaris rejected the table commit"}',
+    { status: 500 }
+  )
+
+  await assert.rejects(
+    readOptimizationResponse(response, "Compaction"),
+    /Polaris rejected the table commit/
+  )
+})
+
+test("preserves a plain-text proxy error", async () => {
+  const response = new Response("Internal Server Error", { status: 500 })
+
+  await assert.rejects(
+    readOptimizationResponse(response, "Snapshot Expiration"),
+    /Internal Server Error/
+  )
+})
+
+test("uses the HTTP status for an empty error response", async () => {
+  const response = new Response(null, {
+    status: 503,
+    statusText: "Service Unavailable",
+  })
+
+  await assert.rejects(
+    readOptimizationResponse(response, "Compaction"),
+    /Failed to run Compaction: 503 Service Unavailable/
+  )
+})

--- a/src/lib/optimization-response.ts
+++ b/src/lib/optimization-response.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ErrorResponse = {
+  error?: unknown
+  message?: unknown
+}
+
+function errorMessage(body: unknown): string | undefined {
+  if (typeof body === "string") {
+    return body.trim() || undefined
+  }
+
+  if (body && typeof body === "object") {
+    const { error, message } = body as ErrorResponse
+    if (typeof message === "string" && message.trim()) {
+      return message
+    }
+    if (typeof error === "string" && error.trim()) {
+      return error
+    }
+  }
+
+  return undefined
+}
+
+export async function readOptimizationResponse(
+  response: Response,
+  operation: string
+): Promise<unknown> {
+  const responseText = await response.text()
+  let body: unknown
+
+  if (responseText) {
+    try {
+      body = JSON.parse(responseText)
+    } catch {
+      body = responseText
+    }
+  }
+
+  if (!response.ok) {
+    const fallback = response.statusText
+      ? `Failed to run ${operation}: ${response.status} ${response.statusText}`
+      : `Failed to run ${operation}: HTTP ${response.status}`
+    throw new Error(errorMessage(body) || fallback)
+  }
+
+  if (responseText && typeof body === "string") {
+    throw new Error(`Invalid response while running ${operation}: ${body}`)
+  }
+
+  return body
+}


### PR DESCRIPTION
## Summary\n\n- preserve JSON and plain-text backend failures in the optimization progress UI instead of replacing them with a JSON parser exception\n- include Spark session startup in each operation's existing error boundary so initialization failures return the operation-specific JSON response\n- add focused response parsing regression tests and run frontend tests in CI\n\n## Context\n\nIssue #222 currently includes only a screenshot of the UI parsing a plain "Internal Server Error" response as JSON. It does not include the backend exception, Polaris catalog configuration, or server logs needed to identify the underlying catalog failure.\n\nThis PR fixes that loss of diagnostic information so a retry surfaces the actual Polaris/Spark error. It intentionally relates to #222 without closing it; the underlying Polaris failure still needs the reporter's newly visible error or backend logs before it can be reproduced and fixed honestly.\n\nRelated to #222.\n\n## Validation\n\n- node --import tsx --test src/lib/*.test.ts (4 passed)\n- Prettier full frontend check\n- TypeScript no-emit typecheck\n- ESLint (0 errors; 5 pre-existing warnings in LocalCatalogWizardModal.tsx)\n- backend: ./gradlew spotlessCheck compileJava