### PR TITLE
feat: enforce the single-backend deployment model

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ docker compose up -d
 
 Access the UI at [http://localhost:3000](http://localhost:3000).
 
+The Java backend supports one replica per PostgreSQL database. See the
+[backend deployment model](docs/deployment.md) for the enforced concurrency model,
+readiness endpoint, and operational implications of embedded Spark.
+
 #### Default Admin Login
 
 - **Username:** `admin`

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -127,6 +127,14 @@ dependencies {
 
   // Password Hashing
   implementation 'org.mindrot:jbcrypt:0.4'
+
+  testImplementation platform('org.junit:junit-bom:5.11.4')
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-core:5.15.2'
+}
+
+test {
+  useJUnitPlatform()
 }
 
 jar {

--- a/backend/src/main/java/io/nimtable/CatalogsServlet.java
+++ b/backend/src/main/java/io/nimtable/CatalogsServlet.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -99,9 +100,10 @@ public class CatalogsServlet extends HttpServlet {
                         .map(Catalog::getName)
                         .collect(Collectors.toList());
 
-        // Combine both lists
-        List<String> allCatalogs = new ArrayList<>(configCatalogs);
-        allCatalogs.addAll(dbCatalogs);
+        // PostgreSQL definitions take precedence over config definitions with the same name,
+        // matching startup registration and Spark configuration.
+        Set<String> allCatalogs = new LinkedHashSet<>(dbCatalogs);
+        allCatalogs.addAll(configCatalogs);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/backend/src/main/java/io/nimtable/Server.java
+++ b/backend/src/main/java/io/nimtable/Server.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.nimtable.db.PersistenceManager;
 import io.nimtable.db.entity.Catalog;
 import io.nimtable.db.repository.CatalogRepository;
+import io.nimtable.deployment.BackendInstanceLock;
+import io.nimtable.deployment.DeploymentStatusServlet;
 import io.nimtable.schedule.ScheduleManager;
 import io.nimtable.spark.LocalSpark;
 import java.io.File;
@@ -227,19 +229,26 @@ public class Server {
         // Initialize Persistence Manager
         PersistenceManager.initialize(dbConfig);
 
+        try (BackendInstanceLock instanceLock =
+                BackendInstanceLock.acquire(PersistenceManager.getDataSource())) {
+            runServer(config, instanceLock);
+        }
+    }
+
+    private static void runServer(Config config, BackendInstanceLock instanceLock)
+            throws Exception {
+
         // --- Instantiate Repositories ---
         CatalogRepository catalogRepository = new CatalogRepository(); // Simple instantiation
 
         // init spark
         LocalSpark.getInstance(config);
 
-        // Initialize and start the schedule manager
-        ScheduleManager scheduleManager = ScheduleManager.getInstance(config);
-        scheduleManager.start();
-
         // Add Servlets to handle API endpoints
         apiContext = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
         apiContext.setContextPath("/api");
+        apiContext.addServlet(
+                new ServletHolder("status", new DeploymentStatusServlet(instanceLock)), "/status");
         apiContext.addServlet(
                 new ServletHolder("catalogs", new CatalogsServlet(config)), "/catalogs/*");
         apiContext.addServlet(
@@ -254,9 +263,23 @@ public class Server {
                 new ServletHolder("distribution", new DistributionServlet(config)),
                 "/distribution/*");
 
-        // Add route for each `/api/catalog/<catalog-name>/*` endpoints
+        // Database definitions take precedence over config definitions with the same name. This
+        // matches CatalogsServlet and LocalSpark and makes restart reconciliation deterministic.
+        List<Catalog> dbCatalogs = catalogRepository.findAll();
+        Set<String> dbCatalogNames = new HashSet<>();
+        for (Catalog catalogEntity : dbCatalogs) {
+            dbCatalogNames.add(catalogEntity.getName());
+        }
+
+        // Add route for each `/api/catalog/<catalog-name>/*` endpoint.
         if (config.catalogs() != null) {
             for (Config.Catalog catalog : config.catalogs()) {
+                if (dbCatalogNames.contains(catalog.name())) {
+                    LOG.info(
+                            "Catalog {} is defined in config and PostgreSQL; using PostgreSQL",
+                            catalog.name());
+                    continue;
+                }
                 if (CATALOG_ADAPTERS.containsKey(catalog.name())) {
                     LOG.warn("Duplicate catalog name in config.yaml, skipping: {}", catalog.name());
                     continue;
@@ -266,14 +289,7 @@ public class Server {
         }
 
         // Add catalogs from database
-        List<Catalog> dbCatalogs = catalogRepository.findAll();
         for (Catalog catalogEntity : dbCatalogs) {
-            if (CATALOG_ADAPTERS.containsKey(catalogEntity.getName())) {
-                LOG.warn(
-                        "Duplicate catalog name in database rows, skipping: {}",
-                        catalogEntity.getName());
-                continue;
-            }
             LOG.info("Creating catalog from database: {}", catalogEntity.getName());
             Map<String, String> properties = new HashMap<>(catalogEntity.getProperties());
             properties.put("type", catalogEntity.getType());
@@ -282,22 +298,27 @@ public class Server {
             registerCatalog(catalogEntity.getName(), properties);
         }
 
+        // Prepare scheduled work only after the catalog state has been fully reconstructed.
+        ScheduleManager scheduleManager = ScheduleManager.getInstance(config, instanceLock);
+
         // Create handler list with API context
         HandlerList handlers = new HandlerList();
         handlers.addHandler(apiContext);
         org.eclipse.jetty.server.Server httpServer =
                 new org.eclipse.jetty.server.Server(
                         new InetSocketAddress(config.server().host(), config.server().port()));
+        httpServer.setStopAtShutdown(true);
         httpServer.setHandler(handlers);
 
-        // Add listener bean to close PersistenceManager and ScheduleManager on shutdown
+        // Add listener bean to close process-local services on shutdown.
         httpServer.addBean(
                 new AbstractLifeCycle.AbstractLifeCycleListener() {
                     @Override
                     public void lifeCycleStopping(LifeCycle event) {
                         LOG.info(
-                                "Shutting down server, closing ScheduleManager and PersistenceManager.");
+                                "Shutting down server, closing scheduler, Spark, catalogs, and persistence");
                         scheduleManager.stop();
+                        LocalSpark.getInstance(config).stop();
                         CATALOG_ADAPTERS.forEach(
                                 (name, adapter) -> {
                                     try {
@@ -313,8 +334,19 @@ public class Server {
                     }
                 });
 
-        httpServer.start();
-        LOG.info("Server started on {}:{}", config.server().host(), config.server().port());
-        httpServer.join();
+        try {
+            httpServer.start();
+            scheduleManager.start();
+            LOG.info("Server started on {}:{}", config.server().host(), config.server().port());
+            httpServer.join();
+        } finally {
+            if (!httpServer.isStopped()) {
+                try {
+                    httpServer.stop();
+                } catch (Exception e) {
+                    LOG.warn("Failed to stop the HTTP server cleanly", e);
+                }
+            }
+        }
     }
 }

--- a/backend/src/main/java/io/nimtable/db/PersistenceManager.java
+++ b/backend/src/main/java/io/nimtable/db/PersistenceManager.java
@@ -63,6 +63,7 @@ public class PersistenceManager {
                 javax.sql.DataSource ds = DatabaseFactory.create(ebeanConfig).dataSource();
                 // Run Flyway migrations
                 FlywayMigrator.migrateDatabase(ds, dbConfig);
+                dataSourceInstance = ds;
             } catch (Exception e) {
                 LOG.error("Failed to initialize persistence: {}", e.getMessage(), e);
                 throw new RuntimeException("Failed to initialize persistence", e);

--- a/backend/src/main/java/io/nimtable/deployment/BackendInstanceLock.java
+++ b/backend/src/main/java/io/nimtable/deployment/BackendInstanceLock.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.deployment;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Holds the PostgreSQL advisory lock that enforces Nimtable's single-backend model. */
+public final class BackendInstanceLock implements AutoCloseable {
+    public static final String DEPLOYMENT_MODE = "single-replica";
+
+    // The ASCII bytes for "NIMTABLE", interpreted as a positive signed bigint.
+    private static final long LOCK_ID = 0x4e494d5441424c45L;
+    private static final Logger LOG = LoggerFactory.getLogger(BackendInstanceLock.class);
+
+    private final Connection connection;
+    private boolean acquired;
+
+    private BackendInstanceLock(Connection connection) {
+        this.connection = connection;
+        this.acquired = true;
+    }
+
+    /**
+     * Acquires a session-level lock on a dedicated database connection.
+     *
+     * <p>The connection remains open for the backend lifetime. PostgreSQL automatically releases
+     * the lock if the process or connection terminates unexpectedly.
+     */
+    public static BackendInstanceLock acquire(DataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection();
+        boolean acquired = false;
+        try {
+            acquired = tryAcquire(connection);
+            if (!acquired) {
+                throw new IllegalStateException(
+                        "Another Nimtable backend is already active for this database. "
+                                + "Nimtable supports exactly one backend replica.");
+            }
+
+            LOG.info("Acquired {} backend deployment lock", DEPLOYMENT_MODE);
+            return new BackendInstanceLock(connection);
+        } finally {
+            if (!acquired) {
+                connection.close();
+            }
+        }
+    }
+
+    private static boolean tryAcquire(Connection connection) throws SQLException {
+        try (PreparedStatement statement =
+                connection.prepareStatement("SELECT pg_try_advisory_lock(?)")) {
+            statement.setLong(1, LOCK_ID);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    throw new SQLException("PostgreSQL did not return an advisory lock result");
+                }
+                return resultSet.getBoolean(1);
+            }
+        }
+    }
+
+    /** Returns whether the lock-owning database session is still usable. */
+    public synchronized boolean isHeld() {
+        if (!acquired) {
+            return false;
+        }
+
+        try {
+            return !connection.isClosed() && connection.isValid(1);
+        } catch (SQLException e) {
+            LOG.error("Failed to validate the backend deployment lock", e);
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!acquired) {
+            return;
+        }
+
+        try (PreparedStatement statement =
+                connection.prepareStatement("SELECT pg_advisory_unlock(?)")) {
+            statement.setLong(1, LOCK_ID);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next() || !resultSet.getBoolean(1)) {
+                    LOG.warn("PostgreSQL reported that the backend deployment lock was not held");
+                }
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to explicitly release the backend deployment lock", e);
+        } finally {
+            acquired = false;
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                LOG.warn("Failed to close the backend deployment lock connection", e);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/io/nimtable/deployment/DeploymentStatusServlet.java
+++ b/backend/src/main/java/io/nimtable/deployment/DeploymentStatusServlet.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.deployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+
+/** Reports the backend deployment model and ownership of its singleton responsibilities. */
+public class DeploymentStatusServlet extends HttpServlet {
+    private final BooleanSupplier lockHeld;
+    private final ObjectMapper mapper;
+
+    public DeploymentStatusServlet(BackendInstanceLock instanceLock) {
+        this(instanceLock::isHeld);
+    }
+
+    DeploymentStatusServlet(BooleanSupplier lockHeld) {
+        this.lockHeld = lockHeld;
+        this.mapper = new ObjectMapper();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        boolean healthy = lockHeld.getAsBoolean();
+        response.setStatus(
+                healthy ? HttpServletResponse.SC_OK : HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        mapper.writeValue(response.getOutputStream(), status(healthy));
+    }
+
+    Map<String, String> status(boolean healthy) {
+        Map<String, String> status = new LinkedHashMap<>();
+        status.put("status", healthy ? "UP" : "DOWN");
+        status.put("deploymentMode", BackendInstanceLock.DEPLOYMENT_MODE);
+        status.put("replicaLock", healthy ? "HELD" : "LOST");
+        status.put("scheduler", "in-process");
+        status.put("spark", "embedded-local");
+        status.put("catalogRegistration", "config-and-postgresql");
+        return status;
+    }
+}

--- a/backend/src/main/java/io/nimtable/schedule/ScheduleManager.java
+++ b/backend/src/main/java/io/nimtable/schedule/ScheduleManager.java
@@ -20,6 +20,7 @@ import io.nimtable.Config;
 import io.nimtable.db.entity.ScheduledTask;
 import io.nimtable.db.repository.CatalogRepository;
 import io.nimtable.db.repository.ScheduledTaskRepository;
+import io.nimtable.deployment.BackendInstanceLock;
 import io.nimtable.spark.LocalSpark;
 import io.nimtable.util.CronUtil;
 import java.time.Instant;
@@ -49,19 +50,22 @@ public class ScheduleManager {
     private final Config config;
     private final ScheduledTaskRepository scheduledTaskRepository;
     private final CatalogRepository catalogRepository;
+    private final BackendInstanceLock instanceLock;
     private final ScheduledExecutorService executorService;
     private boolean isRunning = false;
 
-    private ScheduleManager(Config config) {
+    private ScheduleManager(Config config, BackendInstanceLock instanceLock) {
         this.config = config;
+        this.instanceLock = instanceLock;
         this.scheduledTaskRepository = new ScheduledTaskRepository();
         this.catalogRepository = new CatalogRepository();
         this.executorService = Executors.newScheduledThreadPool(4);
     }
 
-    public static synchronized ScheduleManager getInstance(Config config) {
+    public static synchronized ScheduleManager getInstance(
+            Config config, BackendInstanceLock instanceLock) {
         if (instance == null) {
-            instance = new ScheduleManager(config);
+            instance = new ScheduleManager(config, instanceLock);
         }
         return instance;
     }
@@ -137,6 +141,11 @@ public class ScheduleManager {
     /** Check for tasks that need to be executed and execute them. */
     private void checkAndExecuteTasks() {
         try {
+            if (!instanceLock.isHeld()) {
+                LOG.error("Skipping scheduled work because the backend deployment lock was lost");
+                return;
+            }
+
             List<ScheduledTask> tasksToRun = scheduledTaskRepository.findTasksToRun();
 
             if (tasksToRun.isEmpty()) {

--- a/backend/src/test/java/io/nimtable/deployment/BackendInstanceLockTest.java
+++ b/backend/src/test/java/io/nimtable/deployment/BackendInstanceLockTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+class BackendInstanceLockTest {
+    @Test
+    void acquiresAndReleasesPostgresAdvisoryLock() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement acquireStatement = mock(PreparedStatement.class);
+        PreparedStatement releaseStatement = mock(PreparedStatement.class);
+        ResultSet acquireResult = mock(ResultSet.class);
+        ResultSet releaseResult = mock(ResultSet.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT pg_try_advisory_lock(?)"))
+                .thenReturn(acquireStatement);
+        when(acquireStatement.executeQuery()).thenReturn(acquireResult);
+        when(acquireResult.next()).thenReturn(true);
+        when(acquireResult.getBoolean(1)).thenReturn(true);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.isValid(1)).thenReturn(true);
+        when(connection.prepareStatement("SELECT pg_advisory_unlock(?)"))
+                .thenReturn(releaseStatement);
+        when(releaseStatement.executeQuery()).thenReturn(releaseResult);
+        when(releaseResult.next()).thenReturn(true);
+        when(releaseResult.getBoolean(1)).thenReturn(true);
+
+        BackendInstanceLock instanceLock = BackendInstanceLock.acquire(dataSource);
+        assertTrue(instanceLock.isHeld());
+
+        instanceLock.close();
+
+        assertFalse(instanceLock.isHeld());
+        verify(acquireStatement).setLong(1, 0x4e494d5441424c45L);
+        verify(releaseStatement).setLong(1, 0x4e494d5441424c45L);
+        verify(connection).close();
+    }
+
+    @Test
+    void rejectsASecondBackendAndClosesItsConnection() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement acquireStatement = mock(PreparedStatement.class);
+        ResultSet acquireResult = mock(ResultSet.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT pg_try_advisory_lock(?)"))
+                .thenReturn(acquireStatement);
+        when(acquireStatement.executeQuery()).thenReturn(acquireResult);
+        when(acquireResult.next()).thenReturn(true);
+        when(acquireResult.getBoolean(1)).thenReturn(false);
+
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class, () -> BackendInstanceLock.acquire(dataSource));
+
+        assertTrue(error.getMessage().contains("exactly one backend replica"));
+        verify(connection).close();
+    }
+}

--- a/backend/src/test/java/io/nimtable/deployment/DeploymentStatusServletTest.java
+++ b/backend/src/test/java/io/nimtable/deployment/DeploymentStatusServletTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Nimtable
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nimtable.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DeploymentStatusServletTest {
+    @Test
+    void reportsSingletonOwnershipAndEmbeddedServices() {
+        DeploymentStatusServlet servlet = new DeploymentStatusServlet(() -> true);
+
+        Map<String, String> status = servlet.status(true);
+
+        assertEquals("UP", status.get("status"));
+        assertEquals("single-replica", status.get("deploymentMode"));
+        assertEquals("HELD", status.get("replicaLock"));
+        assertEquals("in-process", status.get("scheduler"));
+        assertEquals("embedded-local", status.get("spark"));
+        assertEquals("config-and-postgresql", status.get("catalogRegistration"));
+    }
+
+    @Test
+    void reportsLockLossAsDown() {
+        DeploymentStatusServlet servlet = new DeploymentStatusServlet(() -> false);
+
+        Map<String, String> status = servlet.status(false);
+
+        assertEquals("DOWN", status.get("status"));
+        assertEquals("LOST", status.get("replicaLock"));
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,8 @@ services:
   nimtable:
     image: ghcr.io/nimtable/nimtable:nightly
     restart: unless-stopped
+    deploy:
+      replicas: 1
     depends_on:
       database:
         condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,25 @@
+# Backend deployment model
+
+Nimtable supports exactly **one backend replica per PostgreSQL database**. The web frontend may be deployed separately, but the Java backend is not horizontally scalable.
+
+This constraint exists because the backend owns three process-local responsibilities:
+
+- scheduled maintenance polling and execution;
+- an embedded Spark session running with `local[*]`;
+- REST catalog adapters reconstructed from `config.yaml` and PostgreSQL.
+
+## Enforcement
+
+At startup, the backend obtains a PostgreSQL session advisory lock on a dedicated database connection before it starts Spark, registers catalogs, or starts the scheduler. If another backend connected to the same database already owns the lock, startup fails with a clear error. PostgreSQL releases the lock if the connection or process terminates.
+
+The supplied Docker Compose deployment also declares one backend replica. Other orchestrators must likewise configure the backend workload with a replica count of one. The database lock remains the authoritative safeguard against an accidental second replica.
+
+`GET /api/status` reports the deployment mode and lock state. It returns HTTP 200 while the lock-owning connection is healthy and HTTP 503 if ownership has been lost. Scheduled polling also stops when the lock is no longer healthy.
+
+## Catalog reconciliation
+
+Catalog adapters are fully reconstructed before scheduled work starts. Catalogs stored in PostgreSQL are loaded in name order and take precedence over a `config.yaml` entry with the same name, matching the catalog API and Spark configuration behavior. A catalog declared only in `config.yaml` is declarative: disconnecting it through the API hides it for the current process, and restarting the backend restores it from the file.
+
+## Operational implications
+
+Spark queries and scheduled maintenance share the backend process and its CPU and memory. Size the single backend for both API and maintenance workloads, and use the status endpoint as its readiness check. External compute/job-runner isolation would require a separate execution protocol and is not part of the currently supported model.


### PR DESCRIPTION
## Summary

- enforce the documented single-backend topology with a PostgreSQL advisory lock before Spark, catalog, and scheduler startup
- expose deployment-model and lock ownership through the status endpoint
- make catalog startup precedence deterministic and stop scheduled polling if lock health is lost
- document the embedded Spark and single-replica constraints

## Validation

- `./gradlew --no-daemon check` (passed; 4 tests)
- `docker compose config --quiet`
- `git diff --check`

Closes #253